### PR TITLE
Fix code scanning alert no. 12: Information exposure through an exception

### DIFF
--- a/app/profile.py
+++ b/app/profile.py
@@ -1,7 +1,8 @@
 from pkg_resources import register_namespace_handler
 from app import application, vehicle_collection
 
-from flask import Flask, request,jsonify
+from flask import Flask, request, jsonify
+import logging
 
 
 
@@ -35,10 +36,11 @@ def update_profile():
             return response
 
         except Exception as e:
+            logging.error("Exception occurred", exc_info=True)
             response = {
                 "status": "Failed",
                 "type": "Update Profile Failed",
-                "msg": e
+                "msg": "An internal error has occurred!"
                 }
             return response
 
@@ -57,10 +59,11 @@ def get_profile(uid):
             }
             return response
         except Exception as e:
+            logging.error("Exception occurred", exc_info=True)
             response = {
                 "status": "Failed",
                 "type": "Get Profile Failed",
-                "msg": e
+                "msg": "An internal error has occurred!"
                 }
             return response
 
@@ -87,9 +90,10 @@ def update_status():
             return response
 
         except Exception as e:
+            logging.error("Exception occurred", exc_info=True)
             response = {
                 "status": "Failed",
                 "type": "Update Profile Status Failed",
-                "msg": e
+                "msg": "An internal error has occurred!"
                 }
             return response


### PR DESCRIPTION
Fixes [https://github.com/kshitijdhara/last-mile-delivery/security/code-scanning/12](https://github.com/kshitijdhara/last-mile-delivery/security/code-scanning/12)

To fix the problem, we need to ensure that detailed exception information is not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling blocks to log the exception and return a generic error message.

1. Import the `logging` module to enable logging of exceptions.
2. Replace the current exception handling blocks to log the exception and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
